### PR TITLE
Legger til kommentar om eksperimentell utloggingsvarsel

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ export interface Params {
   taSurveys?: string;
   urlLookupTable?: boolean;
   shareScreen?: boolean;
-  utloggingsvarsel?: boolean;
+  utloggingsvarsel?: boolean; // Eksperimentell. Inneholder kjente feil.
   logoutUrl?: string;
 }
 


### PR DESCRIPTION
Utloggingsvarsel fungerer ikke som tenkt, men er gjort tilgjengelig i prod. Derfor bør vi ha en tydeliggjøringi docs om at funksjonen inneholder kjente feil.