### PR TITLE
Fjerner taSurveys fra dokumentasjon og types

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ export interface Params {
   feedback?: boolean;
   chatbot?: boolean;
   chatbotVisible?: boolean;
-  taSurveys?: string;
   urlLookupTable?: boolean;
   shareScreen?: boolean;
   utloggingsvarsel?: boolean; // Eksperimentell. Inneholder kjente feil.
@@ -274,11 +273,3 @@ injectDecoratorServerSide({
   dekoratorenUrl: 'http://dekoratoren:8088/dekoratoren',
 })
 ```
-
-### taSurveys (Task Analytics)
-
-Dette er for team som ønsker å sette opp egne Task Analytics-undersøkelser i applikasjonen sin. Hver undersøkelse har en egen id, feks '01234' og denne id'en oppgis som verdi i taSurveys.
-
-Det er mulig å legge inn flere undersøkelser samtidig, ved å legge inn kommaseparerte id'er. Feks '01234,04733...', men kun én undersøkelse blir vist av gangen.
-
-Dersom teamet ditt ønsker å komme igang med Task Analytics, ta kontakt med #team-personbruker på Slack.

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -48,7 +48,6 @@ export interface Params {
     feedback?: boolean;
     chatbot?: boolean;
     chatbotVisible?: boolean;
-    taSurveys?: string;
     urlLookupTable?: boolean;
     shareScreen?: boolean;
     utloggingsvarsel?: boolean;


### PR DESCRIPTION
Funksjonaliteten med taSurveys som ble satt opp som argument fungerte ikke helt som planlagt. Vi har derfor måttet fortsette å bruke Google Tag Manager (GTM) for å få surveys til å vises på tvers av applikasjoner. For å unngå forvirring fjerner vi muligheten for å angi taSurveys inn via dekoratøren.

Sjekket i github, og det ser ikke ut til at noen bruker taSurveys uansett, så det skal være trygd å fjerne.