### PR TITLE
Korrigér feilplassering av header utenfor <body>

### DIFF
--- a/src/csr/functions/csr.ts
+++ b/src/csr/functions/csr.ts
@@ -12,7 +12,7 @@ export const injectDecoratorClientSide = async (props: Props) => {
 
     document.head.insertAdjacentHTML("beforeend", styles);
     document.head.insertAdjacentHTML("beforeend", scripts);
-    document.body.insertAdjacentHTML("beforebegin", header);
+    document.body.insertAdjacentHTML("afterbegin", header);
     document.body.insertAdjacentHTML("beforeend", footer);
 
     var script = document.createElement("script");


### PR DESCRIPTION
Slik det er nå settes header-div-elementet inn _før_ `<body>`.

Formodentligvis er dette ikke ønskelig, det er ihvertfall ikke gyldig HTML :)