### PR TITLE
Fjerner appBase slik at dekoratøren går mot sentral login-instans

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,6 @@ export type DecoratorParams = Partial<{
     shareScreen: boolean;
     logoutUrl: string;
     logoutWarning: boolean;
-    appBase: string;
 }>;
 
 // Bruk

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -54,5 +54,4 @@ export type DecoratorParams = Partial<{
     shareScreen: boolean;
     logoutUrl: string;
     logoutWarning: boolean;
-    appBase: string;
 }>;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjerner appBase. Dekoratøren kjører i stedet mot sentral login-instans fremfor den konsumerende applikasjonens egen sidecar. Dermed slipper man å oppgi grunn-basen for applikasjonen.


