### PR TITLE
Forkaster logging til Amplitude i stillhet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/nav-dekoratoren-moduler",
-    "version": "3.2.1",
+    "version": "3.2.2-beta-stille-logge-amplitude-til-ingenting.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/nav-dekoratoren-moduler",
-            "version": "3.2.1",
+            "version": "3.2.2-beta-stille-logge-amplitude-til-ingenting.0",
             "license": "MIT",
             "dependencies": {
                 "js-cookie": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/nav-dekoratoren-moduler",
-    "version": "3.2.1",
+    "version": "3.2.2-beta-stille-logge-amplitude-til-ingenting.0",
     "description": "Moduler til nav-dekoratoren",
     "author": "NAVIKT",
     "license": "MIT",

--- a/src/csr/functions/amplitude.ts
+++ b/src/csr/functions/amplitude.ts
@@ -26,6 +26,10 @@ export type AutocompleteString = string & {};
 export type AmplitudeEventName = AmplitudeEvents["name"];
 export type AutocompleteEventName = AmplitudeEventName | AutocompleteString;
 
+const silentLogger = () => {
+    return Promise.resolve();
+};
+
 export async function logAmplitudeEvent<TName extends AmplitudeEventName>(params: {
     eventName: TName | AutocompleteString;
     eventData?: TName extends AmplitudeEventName
@@ -38,9 +42,7 @@ export async function logAmplitudeEvent<TName extends AmplitudeEventName>(params
     }
 
     if (!window.dekoratorenAmplitude) {
-        return Promise.reject(
-            "Amplitude not instantiated. Please check users consent for analytics",
-        );
+        return silentLogger;
     }
 
     const isValid = await validateAmplitudeFunction();


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Må sees i sammenheng med https://github.com/navikt/nav-dekoratoren/pull/538

Istedet for å returnere rejected promise, noe som skaper støy i loggene til appene, så returneres en mock av amplitude-instrance. Da vil apper som logger til Amplitude på denne måten ikke oppleve noen feil, mens loggene bare forkastes:

```
const logger = getAmplitudeInstance('appcontext');
logger('sidevisning');
```
## Testing
Testes i nav-enonicxp-dev
