### PR TITLE
Bruker JSDOM serialize() ved SSR file injection

### DIFF
--- a/src/ssr/functions/ssr-file-injection.ts
+++ b/src/ssr/functions/ssr-file-injection.ts
@@ -13,8 +13,11 @@ export const injectDecoratorServerSide = async ({
 }: InjectWithFile): Promise<string> => {
     const file = fs.readFileSync(filePath).toString();
     const dom = new JSDOM(file);
-    return injectDecoratorServerSideDocument({
+    
+    await injectDecoratorServerSideDocument({
         ...props,
         document: dom.window.document,
-    }).then((document) => document.documentElement.outerHTML);
+    });
+
+    return dom.serialize();
 };

--- a/src/ssr/functions/ssr-injection.test.ts
+++ b/src/ssr/functions/ssr-injection.test.ts
@@ -49,7 +49,8 @@ describe("SSR injection", () => {
         expect(htmlWithDecorator).toContain(response.headAssets);
         expect(htmlWithDecorator).toContain(response.header);
         expect(htmlWithDecorator).toContain(response.footer);
-        expect(htmlWithDecorator).toContain(response.scripts);
+        expect(htmlWithDecorator).toContain(response.scripts);        
+        expect(htmlWithDecorator).toContain("<!DOCTYPE html>");
     });
 
     test("Should inject decorator into document", async () => {


### PR DESCRIPTION
👋 

Sørger for at `<!doctype html>` (og andre ting som ikke er en del av selve HTML-dokumentet) ikke forkastes fra HTML templates som parses av JSDOM.