### PR TITLE
Lagt til støtte for custom analytics events

### DIFF
--- a/src/csr/functions/analytics.ts
+++ b/src/csr/functions/analytics.ts
@@ -6,6 +6,12 @@ export type AnalyticsParams<TName extends EventName = EventName> = {
     eventData?: PropertiesFor<TName>;
 };
 
+export type CustomAnalyticsParams = {
+    origin: string;
+    eventName: string;
+    eventData?: Record<string, unknown>;
+};
+
 const waitForRetry = async () => new Promise((resolve) => setTimeout(resolve, 500));
 
 const validateAnalyticsFunction = async (retries = 5): Promise<boolean> => {
@@ -22,9 +28,7 @@ const validateAnalyticsFunction = async (retries = 5): Promise<boolean> => {
     return validateAnalyticsFunction(retries - 1);
 };
 
-export async function logAnalyticsEvent<TName extends EventName>(
-    params: AnalyticsParams<TName>,
-): Promise<any> {
+async function dispatchAnalyticsEvent(params: CustomAnalyticsParams): Promise<any> {
     if (typeof window === "undefined") {
         return Promise.reject("Analytics is only available in the browser");
     }
@@ -38,15 +42,21 @@ export async function logAnalyticsEvent<TName extends EventName>(
     return window.dekoratorenAnalytics(params);
 }
 
+export function logAnalyticsEvent<TName extends EventName>(params: AnalyticsParams<TName>): Promise<any> {
+    return dispatchAnalyticsEvent({ ...params, eventData: params.eventData as Record<string, unknown> | undefined });
+}
+
+export function logAnalyticsCustomEvent(params: CustomAnalyticsParams): Promise<any> {
+    return dispatchAnalyticsEvent(params);
+}
+
 export function getAnalyticsInstance(origin: string) {
-    return <TName extends EventName>(
-        eventName: TName,
-        eventData?: PropertiesFor<TName>,
-    ) => {
-        return logAnalyticsEvent<TName>({
-            eventName,
-            eventData,
-            origin,
-        });
-    };
+    function log<TName extends EventName>(eventName: TName, eventData?: PropertiesFor<TName>) {
+        return logAnalyticsEvent({ eventName, eventData, origin });
+    }
+
+    log.custom = (eventName: string, eventData?: Record<string, unknown>) =>
+        logAnalyticsCustomEvent({ eventName, eventData, origin });
+
+    return log;
 }

--- a/src/csr/index.tsx
+++ b/src/csr/index.tsx
@@ -21,7 +21,7 @@ import {
     DecoratorEnvProps,
     DecoratorFetchProps,
 } from "../common/common-types";
-import { AnalyticsParams, getAnalyticsInstance, logAnalyticsEvent } from "./functions/analytics";
+import { AnalyticsParams, CustomAnalyticsParams, getAnalyticsInstance, logAnalyticsCustomEvent, logAnalyticsEvent } from "./functions/analytics";
 
 export {
     setAvailableLanguages,
@@ -33,6 +33,7 @@ export {
     injectDecoratorClientSide,
     openChatbot,
     logAnalyticsEvent,
+    logAnalyticsCustomEvent,
     getAnalyticsInstance,
     awaitNavWebStorage as awaitDecoratorData,
     isStorageKeyAllowed,
@@ -50,6 +51,7 @@ export type {
     DecoratorEnvProps,
     DecoratorFetchProps,
     AnalyticsParams,
+    CustomAnalyticsParams,
 };
 
 // Re-export from @navikt/analytics-types for convenience

--- a/src/csr/typings.d.ts
+++ b/src/csr/typings.d.ts
@@ -1,9 +1,9 @@
 import { Storage, Consent } from "./functions/storage/storageHelpers";
-import type { AnalyticsParams } from "./functions/analytics";
+import type { CustomAnalyticsParams } from "./functions/analytics";
 
 declare global {
     interface Window {
-        dekoratorenAnalytics: (params: AnalyticsParams) => Promise<any>;
+        dekoratorenAnalytics: (params: CustomAnalyticsParams) => Promise<any>;
         __DECORATOR_DATA__: any;
         webStorageController: {
             isStorageKeyAllowed: (key: string) => boolean;


### PR DESCRIPTION
Bruk samme instance for både typet og custom events:

```ts
import { getAnalyticsInstance } from "@navikt/nav-dekoratoren-moduler";
import { Events, getAnalyticsInstance } from "@navikt/nav-dekoratoren-moduler";

const logger = getAnalyticsInstance("minAppOrigin");

// ✅ Taksonomi-event — strengt typet
logger(Events.SKJEMA_STARTET, {
    skjemaId: "1234",
    skjemanavn: "aap",
});

// ✅ Custom event — app-spesifikt, fri-form data
logger.custom("feedback åpnet", {
    komponent: "feedback-widget",
    steg: 2,
});
```