### PR TITLE
Eksporterer isValidEventName fra analytics-types

### DIFF
--- a/src/csr/index.tsx
+++ b/src/csr/index.tsx
@@ -55,5 +55,5 @@ export type {
 };
 
 // Re-export from @navikt/analytics-types for convenience
-export { Events } from "@navikt/analytics-types";
+export { Events, isValidEventName } from "@navikt/analytics-types";
 export type * from "@navikt/analytics-types";


### PR DESCRIPTION
Bruk `isValidEventName()` når appen din tar imot et event-navn som `string` og må velge mellom
taksonomi-logging og custom logging:

```ts
import { getAnalyticsInstance, isValidEventName } from "@navikt/nav-dekoratoren-moduler";

const logger = getAnalyticsInstance("minAppOrigin");

if (isValidEventName(eventName)) {
    logger(eventName, eventData);
} else {
    logger.custom(eventName, eventData);
}
```