### PR TITLE
Logge konsument

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,3 @@
 # .prettierrc or .prettierrc.yaml
 tabWidth: 4
-printWidth: 100
+printWidth: 80

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/nav-dekoratoren-moduler",
-  "version": "4.2.2",
+  "version": "4.2.3-beta.0",
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "description": "Moduler til nav-dekoratoren",
   "author": "NAVIKT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/nav-dekoratoren-moduler",
-  "version": "4.2.3-beta.5",
+  "version": "4.2.3-beta.6",
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "description": "Moduler til nav-dekoratoren",
   "author": "NAVIKT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/nav-dekoratoren-moduler",
-  "version": "4.2.3-beta.2",
+  "version": "4.2.3-beta.3",
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "description": "Moduler til nav-dekoratoren",
   "author": "NAVIKT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/nav-dekoratoren-moduler",
-  "version": "4.2.3-beta.3",
+  "version": "4.2.3-beta.4",
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "description": "Moduler til nav-dekoratoren",
   "author": "NAVIKT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/nav-dekoratoren-moduler",
-  "version": "4.2.3-beta.1",
+  "version": "4.2.3-beta.2",
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "description": "Moduler til nav-dekoratoren",
   "author": "NAVIKT",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "repository": "navikt/nav-dekoratoren-moduler",
   "main": "csr/index.js",
   "module": "csr/index.js",
+  "types": "csr/index.d.ts",
   "source": "src/csr/index.tsx",
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/nav-dekoratoren-moduler",
-  "version": "4.2.3-beta.0",
+  "version": "4.2.3-beta.1",
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "description": "Moduler til nav-dekoratoren",
   "author": "NAVIKT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/nav-dekoratoren-moduler",
-  "version": "4.2.3-beta.4",
+  "version": "4.2.3-beta.5",
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "description": "Moduler til nav-dekoratoren",
   "author": "NAVIKT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ importers:
         version: 5.2.17(@types/react@19.2.14)(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -5139,7 +5139,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -5148,7 +5148,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -5612,12 +5612,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.6):
+  styled-jsx@5.1.6(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   supports-color@7.2.0:
     dependencies:

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -22,6 +22,7 @@ export type DecoratorEnvProps =
 export type DecoratorFetchProps = {
     params?: DecoratorParams;
     noCache?: boolean;
+    teamName?: string;
 } & DecoratorEnvProps;
 
 export type DecoratorUrlProps = { csr?: boolean } & DecoratorFetchProps;

--- a/src/common/csr-elements.ts
+++ b/src/common/csr-elements.ts
@@ -1,12 +1,6 @@
-import {
-    DecoratorFetchProps,
-    DecoratorUrlProps,
-} from "./common-types";
+import { DecoratorFetchProps, DecoratorUrlProps } from "./common-types";
 import { getDecoratorEndpointUrl } from "./urls";
-import {
-    type EntryPoint,
-    withMetadata,
-} from "./decorator-moduler-metadata";
+import { type EntryPoint, withMetadata } from "./decorator-moduler-metadata";
 
 export const getCsrElements = (
     csrProps: DecoratorFetchProps,
@@ -19,8 +13,9 @@ export const getCsrElements = (
 
     const envUrl = getDecoratorEndpointUrl({
         ...props,
-        params: withMetadata(props.params, entryPoint),
+        params: withMetadata(props.params, entryPoint, csrProps.teamName),
     });
+
     const assetsUrl = getDecoratorEndpointUrl({ ...props, params: undefined });
     const scriptSrc = `${assetsUrl}/client.js`;
 

--- a/src/common/decorator-moduler-metadata.ts
+++ b/src/common/decorator-moduler-metadata.ts
@@ -12,22 +12,36 @@ export type ParamsWithMetadata = DecoratorParams & {
 
 const version = "__NAV_DEKORATOREN_MODULER_VERSION__";
 
-const getNaisConsumerMetadata = () => {
-   if (typeof process === "undefined") return {};
-   return {
+let hasWarnedMissingConsumerIdentity = false;
+
+const getNaisConsumerMetadata = (entryPoint: EntryPoint) => {
+    if (typeof process === "undefined") return {};
+    if (!process.env.NAIS_APP_NAME && !hasWarnedMissingConsumerIdentity) {
+        hasWarnedMissingConsumerIdentity = true;
+        if (entryPoint === "csr") {
+            console.warn(
+                "[nav-dekoratoren-moduler] Dekoratøren kan ikke identifisere teamet ditt for CSR-forespørsler. " +
+                    'Legg til headeren "X-Teamname: <teamnavn>" i forespørslene til dekoratøren for å bli ' +
+                    "identifisert i logger og feilmeldinger.",
+            );
+        } else if (entryPoint === "ssr") {
+            console.warn(
+                "[nav-dekoratoren-moduler] NAIS_APP_NAME ikke satt — SSR-forespørsler kan ikke knyttes til et team.",
+            );
+        }
+    }
+    return {
         ...(process.env.NAIS_APP_NAME && { naisAppName: process.env.NAIS_APP_NAME }),
         ...(process.env.NAIS_NAMESPACE && { naisNamespace: process.env.NAIS_NAMESPACE }),
     };
-}
+};
 
 export const createMetadata = (entryPoint: EntryPoint) => ({
     decoratorModulerVersion: version,
     decoratorModulerEntryPoint: entryPoint,
 });
 
-export const createAnalyticsMetadata = (
-    analyticsEntryPoint: AnalyticsEntryPoint,
-) => ({
+export const createAnalyticsMetadata = (analyticsEntryPoint: AnalyticsEntryPoint) => ({
     decoratorModulerAnalyticsEntryPoint: analyticsEntryPoint,
 });
 
@@ -37,5 +51,5 @@ export const withMetadata = (
 ): ParamsWithMetadata => ({
     ...params,
     ...createMetadata(entryPoint),
-    ...getNaisConsumerMetadata(),
+    ...getNaisConsumerMetadata(entryPoint),
 });

--- a/src/common/decorator-moduler-metadata.ts
+++ b/src/common/decorator-moduler-metadata.ts
@@ -20,9 +20,9 @@ const getNaisConsumerMetadata = (entryPoint: EntryPoint) => {
         hasWarnedMissingConsumerIdentity = true;
         if (entryPoint === "csr") {
             console.warn(
-                "[nav-dekoratoren-moduler] Dekoratøren kan ikke identifisere teamet ditt for CSR-forespørsler. " +
-                    'Legg til headeren "X-Teamname: <teamnavn>" i forespørslene til dekoratøren for å bli ' +
-                    "identifisert i logger og feilmeldinger.",
+                "[nav-dekoratoren-moduler] NAIS_APP_NAME ikke satt — dekoratøren vil bruke Origin-headeren " +
+                    "som fallback for å identifisere teamet ditt. Legg til headeren " +
+                    '"X-Teamname: <teamnavn>" i CSR-forespørslene for nøyaktig identifikasjon.',
             );
         } else if (entryPoint === "ssr") {
             console.warn(

--- a/src/common/decorator-moduler-metadata.ts
+++ b/src/common/decorator-moduler-metadata.ts
@@ -6,9 +6,19 @@ export type AnalyticsEntryPoint = "typed" | "custom" | "legacy";
 export type ParamsWithMetadata = DecoratorParams & {
     decoratorModulerVersion?: string;
     decoratorModulerEntryPoint?: EntryPoint;
+    naisAppName?: string;
+    naisNamespace?: string;
 };
 
 const version = "__NAV_DEKORATOREN_MODULER_VERSION__";
+
+const getNaisConsumerMetadata = () => {
+   if (typeof process === "undefined") return {};
+   return {
+        ...(process.env.NAIS_APP_NAME && { naisAppName: process.env.NAIS_APP_NAME }),
+        ...(process.env.NAIS_NAMESPACE && { naisNamespace: process.env.NAIS_NAMESPACE }),
+    };
+}
 
 export const createMetadata = (entryPoint: EntryPoint) => ({
     decoratorModulerVersion: version,
@@ -27,4 +37,5 @@ export const withMetadata = (
 ): ParamsWithMetadata => ({
     ...params,
     ...createMetadata(entryPoint),
+    ...getNaisConsumerMetadata(),
 });

--- a/src/common/decorator-moduler-metadata.ts
+++ b/src/common/decorator-moduler-metadata.ts
@@ -13,22 +13,13 @@ export type ParamsWithMetadata = DecoratorParams & {
 const version = "__NAV_DEKORATOREN_MODULER_VERSION__";
 
 let hasWarnedMissingConsumerIdentity = false;
-
 const getNaisConsumerMetadata = (entryPoint: EntryPoint) => {
     if (typeof process === "undefined") return {};
-    if (!process.env.NAIS_APP_NAME && !hasWarnedMissingConsumerIdentity) {
+    if (entryPoint === "ssr" && !process.env.NAIS_APP_NAME && !hasWarnedMissingConsumerIdentity) {
         hasWarnedMissingConsumerIdentity = true;
-        if (entryPoint === "csr") {
-            console.warn(
-                "[nav-dekoratoren-moduler] NAIS_APP_NAME ikke satt — dekoratøren vil bruke Origin-headeren " +
-                    "som fallback for å identifisere teamet ditt. Legg til headeren " +
-                    '"X-Teamname: <teamnavn>" i CSR-forespørslene for nøyaktig identifikasjon.',
-            );
-        } else if (entryPoint === "ssr") {
-            console.warn(
-                "[nav-dekoratoren-moduler] NAIS_APP_NAME ikke satt — SSR-forespørsler kan ikke knyttes til et team.",
-            );
-        }
+        console.warn(
+            "[nav-dekoratoren-moduler] NAIS_APP_NAME ikke satt — SSR-forespørsler kan ikke knyttes til et team.",
+        );
     }
     return {
         ...(process.env.NAIS_APP_NAME && { naisAppName: process.env.NAIS_APP_NAME }),

--- a/src/common/decorator-moduler-metadata.ts
+++ b/src/common/decorator-moduler-metadata.ts
@@ -13,17 +13,37 @@ export type ParamsWithMetadata = DecoratorParams & {
 const version = "__NAV_DEKORATOREN_MODULER_VERSION__";
 
 let hasWarnedMissingConsumerIdentity = false;
-const getNaisConsumerMetadata = (entryPoint: EntryPoint) => {
-    if (typeof process === "undefined") return {};
-    if (entryPoint === "ssr" && !process.env.NAIS_APP_NAME && !hasWarnedMissingConsumerIdentity) {
+
+const getNaisConsumerMetadata = (entryPoint: EntryPoint, teamName?: string) => {
+    if (typeof process === "undefined") {
+        if (!teamName && !hasWarnedMissingConsumerIdentity) {
+            hasWarnedMissingConsumerIdentity = true;
+            console.warn(
+                "[nav-dekoratoren-moduler] Dekoratøren kan ikke identifisere teamet ditt for CSR-forespørsler. " +
+                    'Legg til "teamName: <teamnavn>" i konfigurasjonen til injectDecoratorClientSide.',
+            );
+        }
+        return teamName ? { naisAppName: teamName } : {};
+    }
+    if (
+        entryPoint === "ssr" &&
+        !process.env.NAIS_APP_NAME &&
+        !hasWarnedMissingConsumerIdentity
+    ) {
         hasWarnedMissingConsumerIdentity = true;
         console.warn(
             "[nav-dekoratoren-moduler] NAIS_APP_NAME ikke satt — SSR-forespørsler kan ikke knyttes til et team.",
         );
     }
     return {
-        ...(process.env.NAIS_APP_NAME && { naisAppName: process.env.NAIS_APP_NAME }),
-        ...(process.env.NAIS_NAMESPACE && { naisNamespace: process.env.NAIS_NAMESPACE }),
+        ...(process.env.NAIS_APP_NAME && {
+            naisAppName: process.env.NAIS_APP_NAME,
+        }),
+        ...(teamName &&
+            !process.env.NAIS_APP_NAME && { naisAppName: teamName }),
+        ...(process.env.NAIS_NAMESPACE && {
+            naisNamespace: process.env.NAIS_NAMESPACE,
+        }),
     };
 };
 
@@ -32,15 +52,18 @@ export const createMetadata = (entryPoint: EntryPoint) => ({
     decoratorModulerEntryPoint: entryPoint,
 });
 
-export const createAnalyticsMetadata = (analyticsEntryPoint: AnalyticsEntryPoint) => ({
+export const createAnalyticsMetadata = (
+    analyticsEntryPoint: AnalyticsEntryPoint,
+) => ({
     decoratorModulerAnalyticsEntryPoint: analyticsEntryPoint,
 });
 
 export const withMetadata = (
     params: DecoratorParams | undefined,
     entryPoint: EntryPoint,
+    teamName?: string,
 ): ParamsWithMetadata => ({
     ...params,
     ...createMetadata(entryPoint),
-    ...getNaisConsumerMetadata(entryPoint),
+    ...getNaisConsumerMetadata(entryPoint, teamName),
 });

--- a/src/ssr/functions/decorator-elements-service.ts
+++ b/src/ssr/functions/decorator-elements-service.ts
@@ -41,6 +41,7 @@ class DecoratorElementsService {
         });
 
         console.log(`Fetching SSR decorator elements from ${url} with params.`);
+        console.log(url);
 
         if (props.noCache) {
             return fetchSsrElements(url).then((res) => {

--- a/src/ssr/functions/decorator-elements-service.ts
+++ b/src/ssr/functions/decorator-elements-service.ts
@@ -40,6 +40,8 @@ class DecoratorElementsService {
             params: withMetadata(props.params, "ssr"),
         });
 
+        console.log("Fetching SSR decorator elements from ${url} with params.");
+
         if (props.noCache) {
             return fetchSsrElements(url).then((res) => {
                 return res?.elements || this.csrFallback(props);

--- a/src/ssr/functions/decorator-elements-service.ts
+++ b/src/ssr/functions/decorator-elements-service.ts
@@ -40,7 +40,7 @@ class DecoratorElementsService {
             params: withMetadata(props.params, "ssr"),
         });
 
-        console.log("Fetching SSR decorator elements from ${url} with params.");
+        console.log(`Fetching SSR decorator elements from ${url} with params.`);
 
         if (props.noCache) {
             return fetchSsrElements(url).then((res) => {

--- a/src/ssr/functions/decorator-elements-service.ts
+++ b/src/ssr/functions/decorator-elements-service.ts
@@ -40,6 +40,9 @@ class DecoratorElementsService {
             params: withMetadata(props.params, "ssr"),
         });
 
+        console.log(`Fetching SSR decorator elements from ${url} with params.`);
+        console.log(url);
+
         if (props.noCache) {
             return fetchSsrElements(url).then((res) => {
                 return res?.elements || this.csrFallback(props);
@@ -76,7 +79,9 @@ class DecoratorElementsService {
     };
 
     private csrFallback(props: DecoratorFetchProps): DecoratorElements {
-        console.error("Failed to fetch SSR decorator elements - Falling back to CSR elements");
+        console.error(
+            "Failed to fetch SSR decorator elements - Falling back to CSR elements",
+        );
 
         // This is still an SSR integration even when rendering falls back to CSR placeholders.
         const csrElements = getCsrElements(props, "ssr");

--- a/src/ssr/functions/decorator-elements-service.ts
+++ b/src/ssr/functions/decorator-elements-service.ts
@@ -40,9 +40,6 @@ class DecoratorElementsService {
             params: withMetadata(props.params, "ssr"),
         });
 
-        console.log(`Fetching SSR decorator elements from ${url} with params.`);
-        console.log(url);
-
         if (props.noCache) {
             return fetchSsrElements(url).then((res) => {
                 return res?.elements || this.csrFallback(props);


### PR DESCRIPTION
https://github.com/navikt/nav-dekoratoren/issues/800
Se også PR i [nav-dekoratoren](https://github.com/navikt/nav-dekoratoren/pull/916)

`withMetadata()` sender nå automatisk `NAIS_APP_NAME` og `NAIS_NAMESPACE` som `naisAppName`/`naisNamespace` i URL-query på alle `SSR`-kall til dekoratøren for å gjøre det mulig for dekoratøren å identifisere hvilken app og namespace som kaller, uten at konsumentene trenger å gjøre noe.

I nettleser-kontekst er `process` ikke tilgjengelig, så `naisAppName`/`naisNamespace` sendes ikke automatisk. CSR-konsumenter som ønsker å identifisere appen sin kan sende `teamName` i konfigurasjonen til `injectDecoratorClientSide`.

---

Detaljer
- Ny hjelpefunksjon `getNaisConsumerMetadata()` leser `process.env.NAIS_APP_NAME` og `process.env.NAIS_NAMESPACE`
- Trygg for nettleser-kontekst — sjekker `typeof process === "undefined"` før tilgang
- Feltene er valgfrie i `ParamsWithMetadata`-typen og utelates om miljøvariablene ikke er satt
- Varsler i konsoll dersom identitet ikke kan bestemmes